### PR TITLE
Fix libcdio version in CVE-2024-36600 description

### DIFF
--- a/CVE-2024-36600/README.md
+++ b/CVE-2024-36600/README.md
@@ -8,7 +8,8 @@ I did my best to help make this popular library more secure. To that end, I volu
 The length of the buffer allocated for the UTF-8 filename string is the same as the length of the UCS-2 string (which means it can store twice as many UTF-8 bytes as there are characters in the filename). However, it is still possible for the converted UTF-8 string to overflow this buffer if the filename contains glyphs that use 3 or 4-byte UTF-8 sequences. This is because a single character in the filename may be represented by a multi-byte UTF-8 sequence, and the total number of bytes required for the UTF-8 representation could exceed the allocated buffer size, even though the number of characters is the same as the UCS-2 string.
 
 **Vulnerability:**
-Buffer OverFlow Vulnerability in libcdio v2.1.0 allows an attacker to execute arbitrary code via a crafted ISO 9660 image file.
+Buffer OverFlow Vulnerability in libcdio development version since
+[commit 4c840665](https://git.savannah.gnu.org/cgit/libcdio.git/commit/?id=4c840665c6d9cf2ff1cf0cd12f91b25030776c74) allows an attacker to execute arbitrary code via a crafted ISO 9660 image file.
 
 **PoC:**
 It is located in this part. (PoC-libcdio-bof.iso)


### PR DESCRIPTION
Only development version of libcdio is affected, note that in the description.